### PR TITLE
Change default value of `rtd_sphinx_search_file_type` to `minified`

### DIFF
--- a/sphinx_search/extension.py
+++ b/sphinx_search/extension.py
@@ -43,7 +43,7 @@ def inject_static_files(app):
 
 def setup(app):
 
-    app.add_config_value('rtd_sphinx_search_file_type', 'un-minified', 'html')
+    app.add_config_value('rtd_sphinx_search_file_type', 'minified', 'html')
 
     app.connect('builder-inited', inject_static_files)
     app.connect('build-finished', copy_asset_files)


### PR DESCRIPTION
This was set to `un-minified` for debugging purpose.
I think we can change it back to `minified` now.