### PR TITLE
Call preventDefault() in "Esc" event listener

### DIFF
--- a/sphinx_search/static/js/rtd_sphinx_search.js
+++ b/sphinx_search/static/js/rtd_sphinx_search.js
@@ -809,6 +809,7 @@ window.addEventListener("DOMContentLoaded", () => {
         // Escape button
         document.addEventListener("keydown", e => {
             if (e.keyCode === 27) {
+                e.preventDefault();
                 removeSearchModal();
             }
         });


### PR DESCRIPTION
This is untested, but it should prevent the keypress to be propagated after closing the popup, which is not desired, e.g. in https://github.com/sphinx-doc/sphinx/pull/9337.